### PR TITLE
Player store combo

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,7 +27,8 @@
   "env": {
     "browser": true,
     "node": true,
-    "mocha": true
+    "mocha": true,
+    "jasmine": true
   },
   "parser": "babel-eslint",
   "plugins": [
@@ -209,7 +210,7 @@
     "max-params": 0,
     "max-statements": 0,
     "no-bitwise": 1,
-    "no-plusplus": 1,
+    "no-plusplus": [2, {allowForLoopAfterthoughts: true}],
 
     /* Babel */
     // "babel/block-scoped-var": 1,

--- a/demo-server/player-model.js
+++ b/demo-server/player-model.js
@@ -27,6 +27,9 @@ export class PlayerStore {
       if(!playerData.hasOwnProperty('x') || !playerData.hasOwnProperty('y')) {
         throw new Error('x and y must be set on player data');
       }
+      if(playerData.x > this.width || playerData.y > this.height) {
+        throw new Error('x or y are out of range of this map');
+      }
 
       // If we had an old position, remove it from the playerGrid
       // One optimization not done here - if the old position and the new position

--- a/demo-server/player-model.js
+++ b/demo-server/player-model.js
@@ -1,0 +1,43 @@
+import { List, Map } from "immutable";
+
+const players = new Map();
+const playerCoors = new Array(2048 * 2048).map(() => new List());
+
+function cantorPairing(x, y) {
+  return 0.5 * (x + y) * (x + y + 1) + y;
+}
+
+class CantorSearch {
+  constructor() {
+    this.players = new Map();
+    this.playerCoors = new Array(2048 * 2048).map(() => new List());
+  }
+
+  set(id, data) {
+    this.players = this.players.set(id, {
+      position: null,
+      data
+    });
+  }
+  
+  get(id) {
+    return this.players.get(id).data;
+  }
+  
+  setPosition(id, _x, _y) {
+    const player = this.players.get(id);
+  
+    const pos = player.position;
+    const newPos = cantorPairing(_x, _y);
+  
+    this.playerCoors[pos] = this.playerCoors[pos].filter(x => x !== id);
+    this.playerCoors[newPos] = this.playerCoors[newPos].push(id);
+  
+    player.position = newPos;
+  }
+
+  getPosition(x, y) {
+    const pos = cantorPairing(x, y);
+    return this.playerCoors[pos];
+  }
+}

--- a/demo-server/player-model.js
+++ b/demo-server/player-model.js
@@ -23,13 +23,17 @@ export class PlayerStore {
       return this.width * y + x;
     }
 
+    boundsCheck(x, y) {
+      if(x < 0 || y < 0 || x >= this.width || y >= this.height) {
+        throw new Error('x or y are out of range of this map');
+      }
+    }
+
     set(id, playerData) {
       if(!playerData.hasOwnProperty('x') || !playerData.hasOwnProperty('y')) {
         throw new Error('x and y must be set on player data');
       }
-      if(playerData.x > this.width || playerData.y > this.height) {
-        throw new Error('x or y are out of range of this map');
-      }
+      this.boundsCheck(playerData.x, playerData.y);
 
       // If we had an old position, remove it from the playerGrid
       // One optimization not done here - if the old position and the new position
@@ -51,6 +55,7 @@ export class PlayerStore {
     }
 
     inhabitants(x, y) {
+      this.boundsCheck(x, y);
       const pos = this.index(x, y);
       return this.playerGrid[pos];
     }

--- a/test/player-model_spec.js
+++ b/test/player-model_spec.js
@@ -1,6 +1,8 @@
 /* eslint no-undefined: 0 */
 import { expect } from 'chai';
 
+import { List } from 'immutable';
+
 import { PlayerStore, DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../demo-server/player-model';
 
 describe('PlayerStore', () => {
@@ -9,10 +11,12 @@ describe('PlayerStore', () => {
     expect(ps.playerGrid.length).to.equal(DEFAULT_WIDTH * DEFAULT_HEIGHT);
     expect(ps.players.size).to.equal(0);
   });
+
   it('accepts new player data and registers locations', () => {
     const ps = new PlayerStore(4, 4);
 
     expect(ps.lookupPlayer(1)).to.be.undefined;
+    expect(ps.inhabitants(1, 2)).not.to.include(1);
 
     ps.set(1, { x: 1, y: 2 });
 
@@ -20,5 +24,37 @@ describe('PlayerStore', () => {
       x: 1,
       y: 2,
     });
+
+    expect(ps.inhabitants(1, 2)).to.include(1);
+  });
+
+  it('handles the case where a player has moved', () => {
+    const ps = new PlayerStore(16, 16);
+    expect(ps.lookupPlayer(1)).to.be.undefined;
+
+    ps.set(1, { x: 4, y: 6, name: 'Lucky Duck' });
+    expect(ps.lookupPlayer(1)).to.eql({
+      x: 4,
+      y: 6,
+      name: 'Lucky Duck',
+    });
+
+    ps.set(1, { x: 10, y: 6, name: 'Lucky Duck' });
+    expect(ps.lookupPlayer(1)).to.eql({
+      x: 10,
+      y: 6,
+      name: 'Lucky Duck',
+    });
+  });
+
+  it('keeps track of positions across many players', () => {
+    const ps = new PlayerStore(2, 2);
+    ps.set(1, { x: 0, y: 0 });
+    ps.set(2, { x: 0, y: 0 });
+    expect(ps.inhabitants(0, 0)).equal(List.of(1, 2));
+
+    ps.set(1, { x: 1, y: 0 });
+    expect(ps.inhabitants(1, 0)).equal(List.of(1));
+    expect(ps.inhabitants(0, 0)).equal(List.of(2));
   });
 });

--- a/test/player-model_spec.js
+++ b/test/player-model_spec.js
@@ -1,0 +1,24 @@
+/* eslint no-undefined: 0 */
+import { expect } from 'chai';
+
+import { PlayerStore, DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../demo-server/player-model';
+
+describe('PlayerStore', () => {
+  it('initializes with a default big empty setup', () => {
+    const ps = new PlayerStore();
+    expect(ps.playerGrid.length).to.equal(DEFAULT_WIDTH * DEFAULT_HEIGHT);
+    expect(ps.players.size).to.equal(0);
+  });
+  it('accepts new player data and registers locations', () => {
+    const ps = new PlayerStore(4, 4);
+
+    expect(ps.lookupPlayer(1)).to.be.undefined;
+
+    ps.set(1, { x: 1, y: 2 });
+
+    expect(ps.lookupPlayer(1)).to.eql({
+      x: 1,
+      y: 2,
+    });
+  });
+});


### PR DESCRIPTION
This starts off our player store model. Adapted from [a gist](https://gist.github.com/philplckthun/819db9185dcab2ae60fd) by @philplckthun.

Since we have a fixed array with a known width+height, we don't need to use a Cantor pairing function. Later, this index will be really useful as getting the specific spot for the start to an RGBA tuple is:

``` javascript
let idx = playerStore.index(x,y) << 2
```

where `idx+0` is red, `idx+1` is green, `idx+2` is blue, and `idx+3` is the alpha channel within a larger image.

To make tests easier and faster, we allow the `PlayerStore` to be any width and height (even though we expect to always be 2048*2048).
## Usage

``` javascript
> let ps = new PlayerStore(2,2);
> ps.set(1, { x:1, y:0 })
> ps.inhabitants(1,0)
List [ 1 ]
> ps.inhabitants(0,0)
List []
> ps.set(1, { x:0, y: 0})
> ps.inhabitants(0,0)
List [ 1 ]
> ps.inhabitants(1,0)
List []
> ps.lookupPlayer(1)
{ x: 0, y: 0 }
```
