### PR TITLE
Player grid

### DIFF
--- a/src/components/WorldMap.jsx
+++ b/src/components/WorldMap.jsx
@@ -4,6 +4,8 @@ const MAP_SIZE = 2048;
 
 import { index } from '../player-model';
 
+import { List, Range } from 'immutable';
+
 export class WorldMap extends React.Component {
   static displayName = 'CanvasWorldMap';
 
@@ -36,11 +38,28 @@ export class WorldMap extends React.Component {
   }
 
   mouseMoved(evt) {
-    const pos = index(evt.clientX, evt.clientY);
-    const players = this.props.playerGrid[pos];
-    players.forEach(playerID => {
-      console.log(this.props.players.get(playerID));
-    });
+    const rect = this.canvas.getBoundingClientRect();
+    const x = evt.clientX - rect.left;
+    const y = evt.clientY - rect.top;
+
+    // We'll go out a fixed grid size beyond where the mouse is hovering on
+    const centerQuery = index(x, y);
+    const yRange = new Range(-10, 10, 1);
+    const positions = yRange.map(_y => {
+      const pos = centerQuery + _y * MAP_SIZE;
+      return new Range(pos - 10, pos + 10);
+    }).flatten();
+
+    const players = positions.flatMap(
+      (pos) => {
+        return this.props.playerGrid[pos];
+      }
+    ).flatten().map(id => this.props.players.get(id));
+
+    if (! players.isEmpty()) {
+      console.log(players.toArray());
+    }
+
   }
 
   paint(context) {

--- a/src/components/WorldMap.jsx
+++ b/src/components/WorldMap.jsx
@@ -57,7 +57,7 @@ export class WorldMap extends React.Component {
     ).flatten().map(id => this.props.players.get(id));
 
     if (! players.isEmpty()) {
-      console.log(players.toArray());
+      console.log(players.toArray().map(p => p.name));
     }
 
   }

--- a/src/components/WorldMap.jsx
+++ b/src/components/WorldMap.jsx
@@ -2,12 +2,14 @@ import React from 'react';
 
 const MAP_SIZE = 2048;
 
+import { index } from '../player-model';
+
 export class WorldMap extends React.Component {
   static displayName = 'CanvasWorldMap';
 
   static propTypes = {
+    playerGrid: React.PropTypes.any,
     players: React.PropTypes.any,
-    // mapData: React.PropTypes.any,
   }
 
   componentDidMount() {
@@ -34,7 +36,11 @@ export class WorldMap extends React.Component {
   }
 
   mouseMoved(evt) {
-    console.log(evt.clientX, evt.clientY);
+    const pos = index(evt.clientX, evt.clientY);
+    const players = this.props.playerGrid[pos];
+    players.forEach(playerID => {
+      console.log(this.props.players.get(playerID));
+    });
   }
 
   paint(context) {
@@ -58,7 +64,7 @@ export class WorldMap extends React.Component {
             width={MAP_SIZE}
             height={MAP_SIZE}
             ref={(c) => this.canvas = c}
-            onMouseMove={this.mouseMoved}
+            onMouseMove={this.mouseMoved.bind(this)}
             />;
   }
 }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,28 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import withStore from './player-store';
-import { WorldMap } from './components/WorldMap';
-
-import connect from './connect';
-
-const batchEvents = connect('http://127.0.0.1:8090');
-
-import { PlayerModel } from './player-model';
-
-const ps = new PlayerModel();
-const playerStore = batchEvents.map((playerbatch) => {
-  playerbatch.forEach(player => {
-    ps.set(player.id, player);
-  });
-  return {
-    players: ps.players,
-    playerGrid: ps.playerGrid,
-  };
-});
-
-const WorldMapContainer = withStore(playerStore)(WorldMap);
+import { WorldMapStore } from './player-store';
 
 ReactDOM.render(
-  <WorldMapContainer />, document.querySelector('#app')
+  <WorldMapStore />, document.querySelector('#app')
 );

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -8,9 +8,9 @@ import connect from './connect';
 
 const batchEvents = connect('http://127.0.0.1:8090');
 
-import { PlayerStore } from './player-model';
+import { PlayerModel } from './player-model';
 
-const ps = new PlayerStore();
+const ps = new PlayerModel();
 const playerStore = batchEvents.map((playerbatch) => {
   playerbatch.forEach(player => {
     ps.set(player.id, player);

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import { withStore } from 'fluorine-lib';
+import withStore from './player-store';
 import { WorldMap } from './components/WorldMap';
 
 import connect from './connect';
@@ -21,10 +21,7 @@ const playerStore = batchEvents.map((playerbatch) => {
   };
 });
 
-const players = playerStore.map(state => state.players);
-// const playerGrid = playerStore.map(state => state.playerGrid);
-
-const WorldMapContainer = withStore(players, 'players')(WorldMap);
+const WorldMapContainer = withStore(playerStore)(WorldMap);
 
 ReactDOM.render(
   <WorldMapContainer />, document.querySelector('#app')

--- a/src/player-model.js
+++ b/src/player-model.js
@@ -3,6 +3,10 @@ import { List, Map } from 'immutable';
 export const DEFAULT_WIDTH = 2048;
 export const DEFAULT_HEIGHT = 2048;
 
+export function index(x, y, width = DEFAULT_WIDTH) {
+  return width * y + x;
+}
+
 export class PlayerModel {
     constructor(width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT) {
       this.width = width;
@@ -20,7 +24,7 @@ export class PlayerModel {
     }
 
     index(x, y) {
-      return this.width * y + x;
+      return index(x, y, this.width);
     }
 
     boundsCheck(x, y) {

--- a/src/player-model.js
+++ b/src/player-model.js
@@ -3,7 +3,7 @@ import { List, Map } from 'immutable';
 export const DEFAULT_WIDTH = 2048;
 export const DEFAULT_HEIGHT = 2048;
 
-export class PlayerStore {
+export class PlayerModel {
     constructor(width = DEFAULT_WIDTH, height = DEFAULT_HEIGHT) {
       this.width = width;
       this.height = height;

--- a/src/player-store.jsx
+++ b/src/player-store.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+export default function withStore(playerModel) {
+  return Child => class StoreContainer extends React.Component {
+    static displayName = 'PlayerStore'
+    constructor(props) {
+      super(props);
+
+      this.playerModel = playerModel;
+
+      this.state = {
+        players: null,
+        playerGrid: null,
+      };
+    }
+
+    componentWillMount() {
+      this.sub = this.playerModel.subscribe(next => {
+        this.setState({
+          players: next.players,
+          playerGrid: next.playerGrid,
+        });
+      }, err => {
+        throw err;
+      });
+    }
+
+    componentWillUnmount() {
+      this.sub.dispose();
+    }
+
+    render() {
+      if (this.state.players === null) {
+        return null;
+      }
+
+      const props = {};
+      props.players = this.state.players;
+      props.playerGrid = this.state.playerGrid;
+      return <Child {...Object.assign({}, this.props, props)}/>;
+    }
+  };
+}

--- a/src/player-store.jsx
+++ b/src/player-store.jsx
@@ -1,12 +1,32 @@
 import React from 'react';
 
-export default function withStore(playerModel) {
-  return Child => class StoreContainer extends React.Component {
-    static displayName = 'PlayerStore'
+import connect from './connect';
+
+import { WorldMap } from './components/WorldMap';
+import { PlayerModel } from './player-model';
+
+export const WorldMapStore = withConnection('http://127.0.0.1:8090');
+
+export function withConnection(url) {
+  const batchEvents = connect(url);
+  const ps = new PlayerModel();
+
+  const playerData = batchEvents.map((playerbatch) => {
+    playerbatch.forEach(player => {
+      ps.set(player.id, player);
+    });
+    return {
+      players: ps.players,
+      playerGrid: ps.playerGrid,
+    };
+  });
+
+  return class WorldMapContainer extends React.Component {
+    static displayName = 'WorldMapContainer'
     constructor(props) {
       super(props);
 
-      this.playerModel = playerModel;
+      this.playerModel = playerData;
 
       this.state = {
         players: null,
@@ -37,7 +57,8 @@ export default function withStore(playerModel) {
       const props = {};
       props.players = this.state.players;
       props.playerGrid = this.state.playerGrid;
-      return <Child {...Object.assign({}, this.props, props)}/>;
+      return <WorldMap players={this.state.players}
+                       playerGrid={this.state.playerGrid} />;
     }
   };
 }

--- a/test/player-model_spec.js
+++ b/test/player-model_spec.js
@@ -3,17 +3,17 @@ import { expect } from 'chai';
 
 import { List } from 'immutable';
 
-import { PlayerStore, DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../src/player-model';
+import { PlayerModel, DEFAULT_WIDTH, DEFAULT_HEIGHT } from '../src/player-model';
 
-describe('PlayerStore', () => {
+describe('PlayerModel', () => {
   it('initializes with a default big empty setup', () => {
-    const ps = new PlayerStore();
+    const ps = new PlayerModel();
     expect(ps.playerGrid.length).to.equal(DEFAULT_WIDTH * DEFAULT_HEIGHT);
     expect(ps.players.size).to.equal(0);
   });
 
   it('accepts new player data and registers locations', () => {
-    const ps = new PlayerStore(4, 4);
+    const ps = new PlayerModel(4, 4);
 
     expect(ps.get(1)).to.be.undefined;
     expect(ps.playersAt(1, 2)).not.to.include(1);
@@ -29,7 +29,7 @@ describe('PlayerStore', () => {
   });
 
   it('handles the case where a player has moved', () => {
-    const ps = new PlayerStore(16, 16);
+    const ps = new PlayerModel(16, 16);
     expect(ps.get(1)).to.be.undefined;
 
     ps.set(1, { x: 4, y: 6, name: 'Lucky Duck' });
@@ -48,7 +48,7 @@ describe('PlayerStore', () => {
   });
 
   it('keeps track of positions across many players', () => {
-    const ps = new PlayerStore(2, 2);
+    const ps = new PlayerModel(2, 2);
     ps.set(1, { x: 0, y: 0 });
     ps.set(2, { x: 0, y: 0 });
     expect(ps.playersAt(0, 0)).equal(List.of(1, 2));


### PR DESCRIPTION
Here comes the player grid!

When you hover over a player, it shows their data in the console.

![screenshot 2015-12-23 14 13 55](https://cloud.githubusercontent.com/assets/836375/11984249/6860e9f6-a97f-11e5-8a10-bd0ed917845e.png)

Annoyingly, we need some buffer around those player pixels because they're way too small to trigger easily.
